### PR TITLE
FSHL as a Composer package

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ FSHL should be installed using the [PEAR Installer](http://pear.php.net/). This 
 [The PEAR channel](http://pear.kukulich.cz/) that is used to distribute FSHL needs to be registered with the local PEAR environment.
 
 ```
-	pear channel-discover pear.kukulich.cz
+pear channel-discover pear.kukulich.cz
 ```
 
 This has to be done only once. Now the PEAR Installer can be used to install packages from the kukulich channel:
 
 ```
-	pear install kukulich/FSHL
+pear install kukulich/FSHL
 ```
 
 After the installation you can find the FSHL source files inside your local PEAR directory.
@@ -29,24 +29,24 @@ After the installation you can find the FSHL source files inside your local PEAR
 ## Example ##
 
 ```php
-	<?php
-	$highlighter = new \FSHL\Highlighter(new \FSHL\Output\Html());
-	$highlighter->setLexer(new \FSHL\Lexer\Php());
-	echo '<pre>';
-	echo $highlighter->highlight('<?php echo "Hello world!"; ?>');
-	echo '</pre>';
-	?>
+<?php
+$highlighter = new \FSHL\Highlighter(new \FSHL\Output\Html());
+$highlighter->setLexer(new \FSHL\Lexer\Php());
+echo '<pre>';
+echo $highlighter->highlight('<?php echo "Hello world!"; ?>');
+echo '</pre>';
+?>
 ```
 
 Or
 
 ```php
-	<?php
-	$highlighter = new \FSHL\Highlighter(new \FSHL\Output\Html(), \FSHL\Highlighter::OPTION_TAB_INDENT | \FSHL\Highlighter::OPTION_LINE_COUNTER);
-	echo '<pre>';
-	echo $highlighter->highlight('<?php echo "Hello world!"; ?>', new \FSHL\Lexer\Php());
-	echo '</pre>';
-	?>
+<?php
+$highlighter = new \FSHL\Highlighter(new \FSHL\Output\Html(), \FSHL\Highlighter::OPTION_TAB_INDENT | \FSHL\Highlighter::OPTION_LINE_COUNTER);
+echo '<pre>';
+echo $highlighter->highlight('<?php echo "Hello world!"; ?>', new \FSHL\Lexer\Php());
+echo '</pre>';
+?>
 ```
 
 ### Stylesheet ###

--- a/README.md
+++ b/README.md
@@ -9,7 +9,39 @@ FSHL core is very flexible and it is very easy to add new languages. Feel free t
 
 ## Installation ##
 
-FSHL should be installed using the [PEAR Installer](http://pear.php.net/). This installer is the backbone of PEAR, which provides a distribution system for PHP packages, and is shipped with every release of PHP since version 4.3.0.
+### Composer ###
+
+FSHL is available as a [Composer](http://getcomposer.org) package.
+
+To use FSHL in your project, you first need to create a `composer.json` file containing your project's dependencies.
+
+```json
+{
+    "require": {
+        "kukulich/fshl": "2.0.*"
+    }
+}
+```
+
+Then download Composer and install the project's dependencies.
+
+```
+curl -s http://getcomposer.org/installer | php
+php composer.phar install
+```
+
+After the installation you can find the FSHL source files inside your project's `vendor/` directory and load them in your project along with all other dependencies through autoloader.
+
+```php
+<?php
+require 'vendor/autoload.php';
+?>
+```
+
+
+### PEAR ###
+
+FSHL can be installed using the [PEAR Installer](http://pear.php.net/). This installer is the backbone of PEAR, which provides a distribution system for PHP packages, and is shipped with every release of PHP since version 4.3.0.
 
 [The PEAR channel](http://pear.kukulich.cz/) that is used to distribute FSHL needs to be registered with the local PEAR environment.
 

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,18 @@
+{
+	"name": "kukulich/fshl",
+	"description": "FSHL - Fast Syntax Highlighter for PHP 5.3+",
+	"keywords": ["highlighter", "syntax"],
+	"homepage": "http://fshl.kukulich.cz",
+	"license": "GPL-2.0+",
+	"authors": [
+		{
+			"name": "Jaroslav Hanslík",
+			"email": "kontakt@kukulich.cz"
+		}
+	],
+	"require": {
+		"php": ">=5.3.0"
+	},
+	"autoload": {
+		"psr-0": { "FSHL": "FSHL/" }
+}


### PR DESCRIPTION
Makes FSHL a [Composer](http://getcomposer.org) package:
- adds `composer.json` package config file
- mentions Composer in the Installation section of README.

After merging, please add FSHL to the [Packagist](http://packagist.org) - main Composer repository.
